### PR TITLE
Add issue tracker link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ var lock = new AsyncLock({Promise : require('bluebird')});
 
 See [Changelog](./History.md)
 
+## Issues
+
+See [isse tracker](https://github.com/rogierschouten/async-lock/issues).
+
 ## License
 
 MIT, see [LICENSE](./LICENSE)


### PR DESCRIPTION
You'll need to enable the issue tracker for the link to be valid, the link is also already used in package.json, so it'd be great to either enable that link or update it with a valid link.