### PR TITLE
Add an option to allow task to skip the queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ lock.isBusy();
 // Use your own promise library instead of the global Promise variable
 var lock = new AsyncLock({Promise : require('bluebird')}); // Bluebird
 var lock = new AsyncLock({Promise : require('q')}); // Q
+
+// Add a task to the front of the queue waiting for a given lock
+lock.acquire(key, fn1, cb); // runs immediately
+lock.acquire(key, fn2, cb); // added to queue
+lock.acquire(key, priorityFn, cb, {skipQueue: true}); // jumps queue and runs before fn2
 ```
 
 ## Changelog

--- a/lib/index.js
+++ b/lib/index.js
@@ -141,9 +141,14 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 		done(false, new Error('Too much pending tasks'));
 	}
 	else {
-		self.queues[key].push(function () {
+		var taskFn = function () {
 			exec(true);
-		});
+		};
+		if (opts.skipQueue) {
+			self.queues[key].unshift(taskFn);
+		} else {
+			self.queues[key].push(taskFn);
+		}
 
 		var timeout = opts.timeout || self.timeout;
 		if (timeout) {

--- a/test/test.js
+++ b/test/test.js
@@ -288,4 +288,33 @@ describe('AsyncLock Tests', function () {
 		lock.acquire(['A', 'B', 'C'], work, cb);
 		lock.acquire(['A', 'B', 'C'], work, cb);
 	});
+
+
+	it('Allow queue skipping', function (done) {
+		var lock = new AsyncLock();
+		var completeTasks = [];
+		function onDone () {
+			if (completeTasks.length !== 3) return;
+			assert.deepEqual(completeTasks, [1, 3, 2], 'Expected third task to skip queue');
+			done();
+		}
+		lock.acquire('key', function (lockDone) {
+			setTimeout(function () {
+				completeTasks.push(1);
+				lockDone();
+			}, 20);
+		}, onDone);
+		lock.acquire('key', function (lockDone) {
+			setTimeout(function () {
+				completeTasks.push(2);
+				lockDone();
+			}, 20);
+		}, onDone);
+		lock.acquire('key', function (lockDone) {
+			setTimeout(function () {
+				completeTasks.push(3);
+				lockDone();
+			}, 20);
+		}, onDone, { skipQueue: true });
+	});
 });


### PR DESCRIPTION
Execute before other tasks the next time the lock frees if the
following option is given when acquiring the lock:

  { skipQueue: true }

Regression test added.