### PR TITLE
Fix result Promise not resolving when locking empty key array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -203,14 +203,19 @@ AsyncLock.prototype._acquireBatch = function (keys, fn, cb, opts) {
 	}
 	else {
 		var deferred = this._deferPromise();
-		fnx(function (err, ret) {
-			if (err) {
-				deferred.reject(err);
-			}
-			else {
-				deferred.resolve(ret);
-			}
-		});
+		// check for promise mode in case keys is empty array
+		if (fnx.length === 1) {
+			fnx(function (err, ret) {
+				if (err) {
+					deferred.reject(err);
+				}
+				else {
+					deferred.resolve(ret);
+				}
+			});
+		} else {
+			deferred.resolve(fnx());
+		}
 		return deferred.promise;
 	}
 };

--- a/test/test.js
+++ b/test/test.js
@@ -317,4 +317,25 @@ describe('AsyncLock Tests', function () {
 			}, 20);
 		}, onDone, { skipQueue: true });
 	});
+
+
+	it('Promise Mode: should call worker even when no keys are locked', done => {
+		var lock = new AsyncLock();
+		lock.acquire([], () => {
+			done();
+			return Promise.resolve(true);
+		});
+	});
+
+	it('Promise Mode: should pass worker\'s result', () => {
+		var lock = new AsyncLock();
+		return lock.acquire(['key'], () => Promise.resolve('result'))
+			.then(status => assert.equal(status, 'result'));
+	});
+
+	it('Promise Mode: should pass worker\'s result even when no keys are locked', () =>{
+		var lock = new AsyncLock();
+		return lock.acquire([], () => Promise.resolve('result'))
+			.then(status => assert.equal(status, 'result'));
+	}).timeout(20);
 });

--- a/test/test.js
+++ b/test/test.js
@@ -319,23 +319,29 @@ describe('AsyncLock Tests', function () {
 	});
 
 
-	it('Promise Mode: should call worker even when no keys are locked', done => {
+	it('Promise Mode: should call worker even when no keys are locked', function (done) {
 		var lock = new AsyncLock();
-		lock.acquire([], () => {
+		lock.acquire([], function () {
 			done();
-			return Promise.resolve(true);
+			return new Q(true);
 		});
 	});
 
-	it('Promise Mode: should pass worker\'s result', () => {
+	it('Promise Mode: should pass worker\'s result', function() {
 		var lock = new AsyncLock();
-		return lock.acquire(['key'], () => Promise.resolve('result'))
-			.then(status => assert.equal(status, 'result'));
+		return lock.acquire(['key'], function () {
+			return new Q('result');
+		}).then(function (status) {
+			assert.equal(status, 'result');
+		});
 	});
 
-	it('Promise Mode: should pass worker\'s result even when no keys are locked', () =>{
+	it('Promise Mode: should pass worker\'s result even when no keys are locked', function () {
 		var lock = new AsyncLock();
-		return lock.acquire([], () => Promise.resolve('result'))
-			.then(status => assert.equal(status, 'result'));
+		return lock.acquire([], function cb () {
+			return new Q('result');
+		}).then(function (status) {
+			assert.equal(status, 'result');
+		});
 	}).timeout(20);
 });


### PR DESCRIPTION
Pass through critical section result in edge case where acquire was called with empty key list.