### PR TITLE
#17: replace Promise.defer() with new Promise()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,13 +39,20 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 		throw new Error('You must pass a function to execute');
 	}
 
+	// faux-deferred promise using new Promise() (as Promise.defer is deprecated)
+	var deferredResolve = null;
+	var deferredReject = null;
 	var deferred = null;
+
 	if (typeof (cb) !== 'function') {
 		opts = cb;
 		cb = null;
 
 		// will return a promise
-		deferred = this._deferPromise();
+		deferred =  new this.Promise((resolve, reject) => {
+			deferredResolve = resolve;
+			deferredReject = reject;
+		});
 	}
 
 	opts = opts || {};
@@ -71,10 +78,10 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 			else {
 				//promise mode
 				if (err) {
-					deferred.reject(err);
+					deferredReject(err);
 				}
 				else {
-					deferred.resolve(ret);
+					deferredResolve(ret);
 				}
 			}
 			resolved = true;
@@ -160,7 +167,7 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 	}
 
 	if (deferred) {
-		return deferred.promise;
+		return deferred;
 	}
 };
 
@@ -202,21 +209,21 @@ AsyncLock.prototype._acquireBatch = function (keys, fn, cb, opts) {
 		fnx(cb);
 	}
 	else {
-		var deferred = this._deferPromise();
-		// check for promise mode in case keys is empty array
-		if (fnx.length === 1) {
-			fnx(function (err, ret) {
-				if (err) {
-					deferred.reject(err);
-				}
-				else {
-					deferred.resolve(ret);
-				}
-			});
-		} else {
-			deferred.resolve(fnx());
-		}
-		return deferred.promise;
+		return new this.Promise((resolve, reject) => {
+			// check for promise mode in case keys is empty array
+			if (fnx.length === 1) {
+				fnx(function (err, ret) {
+					if (err) {
+						reject(err);
+					}
+					else {
+						resolve(ret);
+					}
+				});
+			} else {
+				resolve(fnx());
+			}
+		});
 	}
 };
 
@@ -242,38 +249,6 @@ AsyncLock.prototype._promiseTry = function(fn) {
 		return this.Promise.resolve(fn());
 	} catch (e) {
 		return this.Promise.reject(e);
-	}
-};
-
-/**
- * Promise.defer() implementation to become independent of Q-specific methods
- */
-AsyncLock.prototype._deferPromise = function() {
-	if (typeof this.Promise.defer === 'function') {
-		// note that Q does not have a constructor with reject/resolve functions so we have no option but use its defer() method
-		return this.Promise.defer();
-	} else {
-		// for promise implementations that don't have a defer() method we create one ourselves
-		var result = {
-			reject: function(err) {
-				// some promise libraries e.g. Q take some time setting the reject property while others do it synchronously
-				return Promise.resolve().then(function() {
-					result.reject(err);
-				});
-			},
-			resolve: function(ret) {
-				// some promise libraries e.g. Q take some time setting the reject property while others do it synchronously
-				return Promise.resolve().then(function() {
-					result.resolve(ret);
-				});
-			},
-			promise: undefined
-		};
-		result.promise = new this.Promise(function(resolve, reject) {
-			result.reject = reject;
-			result.resolve = resolve;
-		});
-		return result;
 	}
 };
 


### PR DESCRIPTION
This PR removes use of `Promise.defer()`, which is deprecated and causes `bluebird` , and perhaps other Promise libraries, to emit console warnings when used. The supported way of doing things is to use `new Promise(...)` instead.

Fixes #17.