### PR TITLE
Fix ES5 compatibility per #21

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,7 @@
 {
 	"node": true, // Enable globals available when code is running inside of the NodeJS runtime environment.
 	"browser": true, // Standard browser globals e.g. `window`, `document`.
-	"esnext": true, // Allow ES.next specific features such as `const` and `let`.
+	"esnext": false, // Allow ES.next specific features such as `const` and `let`.
 	"bitwise": false, // Prohibit bitwise operators (&, |, ^, etc.).
 	"camelcase": false, // Permit only camelcase for `var` and `object indexes`.
 	"curly": false, // Require {} for every new block or scope.
@@ -20,7 +20,8 @@
 	"globals": { // Globals variables.
 		"jasmine": true,
 		"angular": true,
-		"ApplicationConfiguration": true
+		"ApplicationConfiguration": true,
+		"Promise": true
 	},
 	"predef": [ // Extra globals.
 		"define",

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 		cb = null;
 
 		// will return a promise
-		deferred =  new this.Promise((resolve, reject) => {
+		deferred =  new this.Promise(function(resolve, reject) {
 			deferredResolve = resolve;
 			deferredReject = reject;
 		});
@@ -209,7 +209,7 @@ AsyncLock.prototype._acquireBatch = function (keys, fn, cb, opts) {
 		fnx(cb);
 	}
 	else {
-		return new this.Promise((resolve, reject) => {
+		return new this.Promise(function (resolve, reject) {
 			// check for promise mode in case keys is empty array
 			if (fnx.length === 1) {
 				fnx(function (err, ret) {
@@ -253,4 +253,3 @@ AsyncLock.prototype._promiseTry = function(fn) {
 };
 
 module.exports = AsyncLock;
-


### PR DESCRIPTION
- Replaced the two arrow functions with backwards-compatible functions
- Remove 'esnext' compatibility from .jshintrc to catch fat arrows, etc.
- Add `Promise` as a global to avoid lint errors there