### PR TITLE
Remove empty postinstall script from package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "engines": {},
   "scripts": {
     "start": "grunt",
-    "test": "grunt test",
-    "postinstall": ""
+    "test": "grunt test"
   },
   "devDependencies": {
     "bluebird": "^3.5.1",


### PR DESCRIPTION
Removed an empty "postinstall" script definition from the package.json that threw errors when installed using Yarn v2 due to no exit code being returned