### PR TITLE
queues and domains use Map instead of {}

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,11 +6,11 @@ var AsyncLock = function (opts) {
 	this.Promise = opts.Promise || Promise;
 
 	// format: {key : [fn, fn]}
-	// queues[key] = null indicates no job running for key
-	this.queues = {};
+	// queues.has(key) indicates job running for key
+	this.queues = new Map();
 
 	// domain of current running func {key : fn}
-	this.domains = {};
+	this.domains = new Map();
 
 	// lock is reentrant for same domain
 	this.domainReentrant = opts.domainReentrant || false;
@@ -63,10 +63,10 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 
 	var done = function (locked, err, ret) {
 		if (locked) {
-			if (self.queues[key].length === 0) {
-				delete self.queues[key];
+			if (self.queues.get(key).length === 0) {
+				self.queues.delete(key);
 			}
-			delete self.domains[key];
+			self.domains.delete(key);
 		}
 
 		if (!resolved) {
@@ -89,8 +89,8 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 
 		if (locked) {
 			//run next func
-			if (!!self.queues[key] && self.queues[key].length > 0) {
-				self.queues[key].shift()();
+			if (self.queues.has(key) && self.queues.get(key).length > 0) {
+				self.queues.get(key).shift()();
 			}
 		}
 	};
@@ -106,7 +106,7 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 		}
 
 		if (locked) {
-			self.domains[key] = process.domain;
+			self.domains.set(key, process.domain);
 		}
 
 		// Callback mode
@@ -135,26 +135,26 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 		exec = process.domain.bind(exec);
 	}
 
-	if (!self.queues[key]) {
-		self.queues[key] = [];
+	if (!self.queues.has(key)) {
+		self.queues.set(key, []);
 		exec(true);
 	}
-	else if (self.domainReentrant && !!process.domain && process.domain === self.domains[key]) {
+	else if (self.domainReentrant && !!process.domain && process.domain === self.domains.get(key)) {
 		// If code is in the same domain of current running task, run it directly
 		// Since lock is re-enterable
 		exec(false);
 	}
-	else if (self.queues[key].length >= self.maxPending) {
-		done(false, new Error('Too much pending tasks'));
+	else if (self.queues.get(key).length >= self.maxPending) {
+		done(false, new Error('Too many pending tasks'));
 	}
 	else {
 		var taskFn = function () {
 			exec(true);
 		};
 		if (opts.skipQueue) {
-			self.queues[key].unshift(taskFn);
+			self.queues.get(key).unshift(taskFn);
 		} else {
-			self.queues[key].push(taskFn);
+			self.queues.get(key).push(taskFn);
 		}
 
 		var timeout = opts.timeout || self.timeout;
@@ -234,10 +234,10 @@ AsyncLock.prototype._acquireBatch = function (keys, fn, cb, opts) {
  */
 AsyncLock.prototype.isBusy = function (key) {
 	if (!key) {
-		return Object.keys(this.queues).length > 0;
+		return this.queues.size > 0;
 	}
 	else {
-		return !!this.queues[key];
+		return this.queues.has(key);
 	}
 };
 


### PR DESCRIPTION
Changed to avoid clashes with keys in object prototype, eg using 'constructor' as a key caused an error to be thrown