### PR TITLE
Fix single key test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,7 @@ describe('AsyncLock Tests', function () {
 			lock.acquire(key, function (cb) {
 				assert(!isRunning[key]);
 				assert(lock.isBusy() && lock.isBusy(key));
+				isRunning[key] = true;
 
 				var timespan = Math.random() * 10;
 				console.log('task%s(key%s) start, %s ms', number, key, timespan);


### PR DESCRIPTION
The test checks the isRunning object each time a key is acquired to make sure nothing else is using that key; but the isRunning object is never actually updated, so the test cannot fail. This commit adds the missing state change.