### PR TITLE
Introducing a new option: maxOccupationTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Lock on asynchronous code
 * ES6 promise supported
 * Multiple keys lock supported
 * Timeout supported
+* Occupation time limit supported
 * Pending task limit supported
 * Domain reentrant supported
 * 100% code coverage
@@ -129,6 +130,12 @@ d.run(function() {
 var lock = new AsyncLock({timeout: 5000});
 lock.acquire(key, fn, function(err, ret) {
 	// timed out error will be returned here if lock not acquired in given time
+});
+
+// Specify max occupation time
+var lock = new AsyncLock({maxOccupationTime: 3000});
+lock.acquire(key, fn, function(err, ret) {
+	// occupation time exceeded error will be returned here if job not completed in given time
 });
 
 // Set max pending tasks

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ var AsyncLock = function (opts) {
 	}
 
 	this.timeout = opts.timeout || AsyncLock.DEFAULT_TIMEOUT;
+	this.maxWaitTime = opts.maxWaitTime || AsyncLock.DEFAULT_MAX_WAIT_TIME;
 	if (opts.maxPending === Infinity || (Number.isInteger(opts.maxPending) && opts.maxPending >= 0)) {
 		this.maxPending = opts.maxPending;
 	} else {
@@ -30,6 +31,7 @@ var AsyncLock = function (opts) {
 };
 
 AsyncLock.DEFAULT_TIMEOUT = 0; //Never
+AsyncLock.DEFAULT_MAX_WAIT_TIME = 0; //Never
 AsyncLock.DEFAULT_MAX_PENDING = 1000;
 
 /**
@@ -175,6 +177,15 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 				timer = null;
 				done(false, new Error('async-lock timed out'));
 			}, timeout);
+		}
+
+
+		var maxWaitTime = opts.maxWaitTime || self.maxWaitTime;
+		if (maxWaitTime) {
+			timer = setTimeout(function () {
+				timer = null;
+				done(locked);
+			}, maxWaitTime);
 		}
 	}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -189,7 +189,7 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 			}
 			occupationTimer = setTimeout(function () {
 				if (!!self.queues[key]) {
-					done(false, new Error("Maximum occupation time is exceeded"));
+					done(false, new Error('Maximum occupation time is exceeded'));
 				}
 			}, maxOccupationTime);
 		}

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,6 +75,12 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 	var self = this;
 
 	var done = function (locked, err, ret) {
+
+		if (occupationTimer) {
+			clearTimeout(occupationTimer);
+			occupationTimer = null;
+		}
+
 		if (locked) {
 			if (!!self.queues[key] && self.queues[key].length === 0) {
 				delete self.queues[key];
@@ -184,9 +190,6 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 
 	var maxOccupationTime = opts.maxOccupationTime || self.maxOccupationTime;
 		if (maxOccupationTime) {
-			if (occupationTimer) {
-				clearTimeout(occupationTimer);
-			}
 			occupationTimer = setTimeout(function () {
 				if (!!self.queues[key]) {
 					done(false, new Error('Maximum occupation time is exceeded'));

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,12 +102,14 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 		}
 
 		if (locked) {
-			//run next func
+			//run next func & set a max wait time for that
 			if (!!self.queues[key] && self.queues[key].length > 0) {
 				var maxWaitTime = opts.maxWaitTime || self.maxWaitTime;
 				if (maxWaitTime) {
 					setTimeout(function () {
-						done(true);
+						if (!!self.queues[key]) {
+							done(locked);
+						}
 					}, maxWaitTime);
 				}
 				self.queues[key].shift()();
@@ -144,11 +146,11 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 			self._promiseTry(function () {
 				return fn();
 			})
-				.then(function(ret){
-					done(locked, undefined, ret);
-				}, function(error){
-					done(locked, error);
-				});
+			.then(function(ret){
+				done(locked, undefined, ret);
+			}, function(error){
+				done(locked, error);
+			});
 		}
 	};
 	if (self.domainReentrant && !!process.domain) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ var AsyncLock = function (opts) {
 	}
 
 	this.timeout = opts.timeout || AsyncLock.DEFAULT_TIMEOUT;
-	this.maxWaitTime = opts.maxWaitTime || AsyncLock.DEFAULT_MAX_WAIT_TIME;
+	this.maxOccupationTime = opts.maxOccupationTime || AsyncLock.DEFAULT_MAX_OCCUPATION_TIME;
 	if (opts.maxPending === Infinity || (Number.isInteger(opts.maxPending) && opts.maxPending >= 0)) {
 		this.maxPending = opts.maxPending;
 	} else {
@@ -31,7 +31,7 @@ var AsyncLock = function (opts) {
 };
 
 AsyncLock.DEFAULT_TIMEOUT = 0; //Never
-AsyncLock.DEFAULT_MAX_WAIT_TIME = 0; //Never
+AsyncLock.DEFAULT_MAX_OCCUPATION_TIME = 0; //Never
 AsyncLock.DEFAULT_MAX_PENDING = 1000;
 
 /**
@@ -71,6 +71,7 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 
 	var resolved = false;
 	var timer = null;
+	var occupationTimer = null;
 	var self = this;
 
 	var done = function (locked, err, ret) {
@@ -102,16 +103,8 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 		}
 
 		if (locked) {
-			//run next func & set a max wait time for that
+			//run next func
 			if (!!self.queues[key] && self.queues[key].length > 0) {
-				var maxWaitTime = opts.maxWaitTime || self.maxWaitTime;
-				if (maxWaitTime) {
-					setTimeout(function () {
-						if (!!self.queues[key]) {
-							done(locked);
-						}
-					}, maxWaitTime);
-				}
 				self.queues[key].shift()();
 			}
 		}
@@ -153,6 +146,7 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 			});
 		}
 	};
+
 	if (self.domainReentrant && !!process.domain) {
 		exec = process.domain.bind(exec);
 	}
@@ -186,9 +180,19 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 				done(false, new Error('async-lock timed out'));
 			}, timeout);
 		}
-
-
 	}
+
+	var maxOccupationTime = opts.maxOccupationTime || self.maxOccupationTime;
+		if (maxOccupationTime) {
+			if (occupationTimer) {
+				clearTimeout(occupationTimer);
+			}
+			occupationTimer = setTimeout(function () {
+				if (!!self.queues[key]) {
+					done(false, new Error("Maximum occupation time is exceeded"));
+				}
+			}, maxOccupationTime);
+		}
 
 	if (deferred) {
 		return deferred;

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 
 	var done = function (locked, err, ret) {
 		if (locked) {
-			if (self.queues[key].length === 0) {
+			if (self.queues[key] && self.queues[key].length === 0) {
 				delete self.queues[key];
 			}
 			if (self.domainReentrant) {
@@ -104,6 +104,12 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 		if (locked) {
 			//run next func
 			if (!!self.queues[key] && self.queues[key].length > 0) {
+				var maxWaitTime = opts.maxWaitTime || self.maxWaitTime;
+				if (maxWaitTime) {
+					setTimeout(function () {
+						done(true);
+					}, maxWaitTime);
+				}
 				self.queues[key].shift()();
 			}
 		}
@@ -138,11 +144,11 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 			self._promiseTry(function () {
 				return fn();
 			})
-			.then(function(ret){
-				done(locked, undefined, ret);
-			}, function(error){
-				done(locked, error);
-			});
+				.then(function(ret){
+					done(locked, undefined, ret);
+				}, function(error){
+					done(locked, error);
+				});
 		}
 	};
 	if (self.domainReentrant && !!process.domain) {
@@ -180,13 +186,6 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 		}
 
 
-		var maxWaitTime = opts.maxWaitTime || self.maxWaitTime;
-		if (maxWaitTime) {
-			timer = setTimeout(function () {
-				timer = null;
-				done(true);
-			}, maxWaitTime);
-		}
 	}
 
 	if (deferred) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -184,7 +184,7 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 		if (maxWaitTime) {
 			timer = setTimeout(function () {
 				timer = null;
-				done(locked);
+				done(true);
 			}, maxWaitTime);
 		}
 	}

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ AsyncLock.prototype.acquire = function (key, fn, cb, opts) {
 
 	var done = function (locked, err, ret) {
 		if (locked) {
-			if (self.queues[key] && self.queues[key].length === 0) {
+			if (!!self.queues[key] && self.queues[key].length === 0) {
 				delete self.queues[key];
 			}
 			if (self.domainReentrant) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "async-lock",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1543,9 +1543,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "interpret": {
@@ -3468,9 +3468,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yargs": {

--- a/test/test.js
+++ b/test/test.js
@@ -164,8 +164,8 @@ describe('AsyncLock Tests', function () {
 		var order = 0;
 
 		lock.acquire('key', function (cb) {
-			callBack = cb
-			setTimeout(() => {
+			callBack = cb;
+			setTimeout(function(){
 				assert.equal(++order, 3);
 				if (!maxOccupationTimeExceeded) cb();
 				assert(maxOccupationTimeExceeded);

--- a/test/test.js
+++ b/test/test.js
@@ -157,6 +157,37 @@ describe('AsyncLock Tests', function () {
 			});
 	});
 
+	it('Max occupation time test', function (done) {
+		var lock = new AsyncLock({ maxOccupationTime: 10 });
+		var maxOccupationTimeExceeded = false;
+		var callBack = null;
+		var order = 0;
+
+		lock.acquire('key', function (cb) {
+			callBack = cb
+			setTimeout(() => {
+				assert.equal(++order, 3);
+				if (!maxOccupationTimeExceeded) cb();
+				assert(maxOccupationTimeExceeded);
+				done();
+			}, 50);
+		})
+		.catch(function (err) {
+			// max occupation time is passed
+			console.log(err);
+			assert.equal(++order, 1);
+			// release the lock and cancel the job if needed
+			maxOccupationTimeExceeded = true;
+			callBack();
+		});
+
+		lock.acquire('key', function (cb) {
+			// Should be executed first
+			assert.equal(++order, 2);
+			cb();
+		});
+	});
+
 	it('Promise mode (Q)', function (done) {
 		var lock = new AsyncLock();
 		var value = 0;


### PR DESCRIPTION
**maxWaitTime** is another form of timeout that covers some use-cases that **timeout** option might not be useful. 
In case of **timeout**, Async-lock would throw an error, and then the queue will lose all of its waiting items.
**maxWaitTime** is a timeout for every single item and if the function exceeds the time, we release the lock and let the next task acquire the lock without canceling the unfinished task.

In collaboration with @ThePiz, we suggest this new option as we are using Async-lock in our project & this feature is essential for our use case.
