### PR TITLE
Change acquireBatch not to mutate (fixes #53)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -231,10 +231,9 @@ AsyncLock.prototype._acquireBatch = function (keys, fn, cb, opts) {
 		};
 	};
 
-	var fnx = fn;
-	keys.reverse().forEach(function (key) {
-		fnx = getFn(key, fnx);
-	});
+	var fnx = keys.reduceRight(function (prev, key) {
+		return getFn(key, prev);
+	}, fn);
 
 	if (typeof (cb) === 'function') {
 		fnx(cb);

--- a/test/test.js
+++ b/test/test.js
@@ -427,10 +427,9 @@ describe('AsyncLock Tests', function () {
 	it('Does not mutate key array during batch acquire', function () {
 		var lock = new AsyncLock();
 		var keys = [1, 2, 3];
-		return lock.acquire(keys, function (cb) {
-			cb();
-		}).then(function () {
-			assert.deepEqual(keys, [1, 2, 3]);
-		});
+		return lock.acquire(keys, function () { })
+			.then(function () {
+				assert.deepEqual(keys, [1, 2, 3]);
+			});
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -424,4 +424,13 @@ describe('AsyncLock Tests', function () {
 		});
 	}).timeout(20);
 
+	it('Does not mutate key array during batch acquire', function () {
+		var lock = new AsyncLock();
+		var keys = [1, 2, 3];
+		return lock.acquire(keys, function (cb) {
+			cb();
+		}).then(function () {
+			assert.deepEqual(keys, [1, 2, 3]);
+		});
+	});
 });


### PR DESCRIPTION
Ended up using `reduceRight`. In my workaround in my own code I copied the key array with the spread operator, i.e. `[...keys]`. However, that requires ES6 and this project is still set up for ES5.

In the end, using `reduceRight` seems like the more elegant solution anyway. Plus it should be more performant since we don't need to create a copy and we only need to walk the array once.